### PR TITLE
#5 build: fixed build-related problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/keystore.properties
+
 *.iml
 .gradle
 /local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,31 @@ plugins {
     id 'com.google.gms.google-services'
 }
 
+// Create a variable called keystorePropertiesFile, and initialize it to your
+// keystore.properties file, in the rootProject folder.
+def keystorePropertiesFile = rootProject.file("keystore.properties")
+
+// Initialize a new Properties() object called keystoreProperties.
+def keystoreProperties = new Properties()
+
+// Load your keystore.properties file into the keystoreProperties object.
+keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+
 android {
+    signingConfigs {
+        release {
+            storeFile file('C:\\KEYSTORE_PATH\\my_app.jks')
+            storePassword 'abcd1234'
+            keyAlias 'ABCD'
+            keyPassword 'abcd1234'
+        }
+        myConfig {
+            storeFile file(keystoreProperties['storeFile'])
+            storePassword keystoreProperties['storePassword']
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+        }
+    }
     compileSdk 32
 
     defaultConfig {
@@ -19,8 +43,16 @@ android {
 
     buildTypes {
         release {
+//            debuggable true
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+//            signingConfig signingConfigs.myConfig
+        }
+        myRelease {
+            debuggable true
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.myConfig
         }
     }
     compileOptions {

--- a/app/src/main/java/com/juhnny/dailydiscovery/Response.kt
+++ b/app/src/main/java/com/juhnny/dailydiscovery/Response.kt
@@ -1,8 +1,4 @@
 package com.juhnny.dailydiscovery
 
-data class Response<T>(val responseHeader: com.juhnny.dailydiscovery.ResponseHeader,
-                       val responseBody: com.juhnny.dailydiscovery.ResponseBody<T>) {
-
-
-
-}
+data class Response<T>(val responseHeader: ResponseHeader,
+                       val responseBody: ResponseBody<T>) {}

--- a/app/src/main/java/com/juhnny/dailydiscovery/ResponseBody.kt
+++ b/app/src/main/java/com/juhnny/dailydiscovery/ResponseBody.kt
@@ -1,5 +1,14 @@
 package com.juhnny.dailydiscovery
 
+import androidx.annotation.Keep
+
+// release build에서 Retrofit2가 json을 변환하지 못하는 문제 발생
+// 서버로부터 들어오는 데이터는 String으로 찍어보니 문제 없었음
+// build.grade(app)의 buildTypes의 release에서 minifyEnabled true를 해제하니 전환 성공
+// minify는 빌드 시 쓰이지 않는 클래스들을 제외시키는 것
+// 즉, 이 데이터클래스들이 쓰이지 않는다고 판단해서 빌드에 포함이 되지 않아 Retrofit2에서 파싱하지 못한 것
+// 클래스에 @Keep annotation을 사용하면 minify 시 무조건 빌드에 포함됨 -> 해결!
+@Keep
 data class ResponseBody<T> (val itemCount:Int,
                             val items:List<T>) {
 

--- a/app/src/main/java/com/juhnny/dailydiscovery/ResponseHeader.kt
+++ b/app/src/main/java/com/juhnny/dailydiscovery/ResponseHeader.kt
@@ -1,4 +1,7 @@
 package com.juhnny.dailydiscovery
 
+import androidx.annotation.Keep
+
+@Keep
 data class ResponseHeader(val resultMsg:String) {
 }

--- a/app/src/main/java/com/juhnny/dailydiscovery/TodayFragment.kt
+++ b/app/src/main/java/com/juhnny/dailydiscovery/TodayFragment.kt
@@ -189,8 +189,12 @@ class TodayFragment : Fragment() {
             ) {
                 val myResponse = response.body()
                 val resultMsg = myResponse?.responseHeader?.resultMsg ?: ""
-                val itemCnt = myResponse?.responseBody?.itemCount ?: 0
+                val itemCnt = myResponse?.responseBody?.itemCount ?: -1
                 val photos = myResponse?.responseBody?.items ?: mutableListOf()
+                Log.e("TodayFrag loadMainPhotos - response", "$response")
+                Log.e("TodayFrag loadMainPhotos - myResponse", "${response.body()}")
+                Log.e("TodayFrag loadMainPhotos - photos", "$photos")
+                if(photos.isEmpty()) return
                 b.tvPostcard1.text = "#" + photos[0].topic
                 b.tvPostcard2.text = photos[1].topic
                 b.tvPostcard3.text = photos[2].topic
@@ -202,6 +206,17 @@ class TodayFragment : Fragment() {
             override fun onFailure(call: Call<Response<Photo>>, t: Throwable) {
                 Log.e("TodayFrag loadMainPhotos() Failure", "${t.message}")
             }
+        })
+
+        RetrofitHelper.getRetrofitInterface().loadMainPhotosString().enqueue(object : Callback<String>{
+            override fun onResponse(call: Call<String>, response: retrofit2.Response<String>) {
+                Log.e("TodayFrag loadMainPhotosString Success", "${response.body()}")
+            }
+
+            override fun onFailure(call: Call<String>, t: Throwable) {
+                Log.e("TodayFrag loadMainPhotosString Failure", "")
+            }
+
         })
     }
 


### PR DESCRIPTION
build.gradle
- debuggable true 추가 : 디버그 도구를 사용 가능하도록
- ResponseHeader.kt, ResponseHeader.kt
  - @Keep annotation 추가 : minify 시 누락되는 클래스들. Retrofit이 파싱에 실패해 NPE 발생하였음
- 프로젝트 폴더에 keystore.properties 생성(.gitignore에 추가), 키스토어 정보 저장, signingConfigs에서 참조. Git 공유 시 키스토어 정보 보안 목적